### PR TITLE
Fix main process env bug

### DIFF
--- a/script/build-main.ts
+++ b/script/build-main.ts
@@ -19,6 +19,7 @@ const argv = minimist(process.argv.slice(2))
 const opts = options(argv.env)
 const TAG = '[build-main.ts]'
 const spinner = ora(`${TAG} Electron build...`)
+process.env.NODE_ENV = argv.env
 
 if (argv.watch) {
   waitOn({ port: process.env.PORT as string }).then(msg => {

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,7 +1,7 @@
 
 declare namespace NodeJS {
   interface ProcessEnv {
-    readonly NODE_ENV: 'development' | 'production'
+    NODE_ENV: 'development' | 'production'
     readonly PORT: string
   }
 }


### PR DESCRIPTION
In the current environment, environment variables are not set correctly, causing the main process to fail to obtain the value of `process.env.NODE_ENV` normally. This PR fixes this problem.