### PR TITLE
fix: tsconfig support ESM

### DIFF
--- a/script/rollup.config.ts
+++ b/script/rollup.config.ts
@@ -20,9 +20,7 @@ export default (env = 'production') => {
       nodeResolve(),
       commonjs(),
       json(),
-      typescript({
-        module: 'ESNext',
-      }),
+      typescript(),
       alias({
         entries: [
           { find: '@render', replacement: join(__dirname, '../src/render') },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
+    "module": "ESNext",
     "moduleResolution": "node",
     "importHelpers": true,
     "jsx": "preserve",
@@ -17,5 +17,10 @@
       "@root/*": ["./*"]
     },
     "allowSyntheticDefaultImports": true
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
   }
 }


### PR DESCRIPTION
你好，这个仓库的 [#issues14](https://github.com/caoxiemeihao/electron-vue-vite/issues/14)中提到了`tsconfig.json` 的 `compilerOptions.module` 改成 `esnext` 会报错的问题。其实你已经在rollup的配置中对node_modules的包使用[commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs)插件进行了cjs->esm的转换，所以`compilerOptions.module` 改成 `esnext`应该是没有问题的。

issues中提到的问题实际上是由于`ts-node`导致的，因为`ts-node`你没有指定具体的`tsconfig`，所以它就自动使用了项目的`tsconfig`，如果此时将`compilerOptions.module` 改成 `esnext`会引起`ts-node`无法使用。这里直接用`ts-node`的配置放在`tsconfig`中用于指定`ts-node`的`module`形式就行了。