### PR TITLE
WIP feat: add vscode debug file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "scripts": {
     "dev": "node scripts/watch.mjs",
-    "build": "vue-tsc --project packages/renderer/tsconfig.json --noEmit && node scripts/build.mjs && electron-builder"
+    "prebuild": "vue-tsc --project packages/renderer/tsconfig.json --noEmit && node scripts/build.mjs",
+    "build": "npm run prebuild && electron-builder",
+    "debug": "npm run prebuild && vite ./packages/renderer"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/packages/main/vite.config.ts
+++ b/packages/main/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
       formats: ['cjs'],
       fileName: () => '[name].cjs',
     },
-    minify: process.env./* from mode option */NODE_ENV === 'production',
+    minify: false,
+    sourcemap: true,
     emptyOutDir: true,
     rollupOptions: {
       external: [


### PR DESCRIPTION
使用方法

启动 vite render server

```shell
npm run debug
```

之后在主进程和渲染进程打几个断点，点击 vscode 调试 all 任务执行。即可单步调试 render 服务和 main 进程。

需要安装 vscode 插件 Debugger for Chrome

ref: 
* https://gist.github.com/cecilemuller/2963155d0f249c1544289b78a1cdd695
* https://nklayman.github.io/vue-cli-plugin-electron-builder/guide/testingAndDebugging.html#renderer-process-main-app
* https://zhuanlan.zhihu.com/p/91259973
* https://www.electronjs.org/docs/latest/tutorial/debugging-vscode
* https://github.com/octref/vscode-electron-debug/blob/master/electron-quick-start/.vscode/launch.json
* https://github.com/vitejs/vite/discussions/4065