### PR TITLE
feat: add inspector node debug support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,23 +1,17 @@
-
-
 {
   "version": "0.2.0",
   "configurations": [
     {
       "type": "node",
       "request": "launch",
-      "name": "Main",
+      "name": "Main(inspector)",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
-      // "program": "${workspaceRoot}/packages/main/index.ts",
-      // "outFiles": [
-      //   "${workspaceRoot}/dist/main/index.cjs"
-      // ],
       "runtimeArgs": [
-        "./dist/main/index.cjs",
+        "--remote-debugging-port=9222",
+        "${workspaceFolder}/dist/main/index.cjs",
       ],
       "env": {
-        "VITE_DEV_SERVER_HOST": "127.0.0.1",
-        "VITE_DEV_SERVER_PORT": "3344"
+        "DEBUG": "true",
       },
       "windows": {
         "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
@@ -27,18 +21,51 @@
     {
       "type": "chrome",
       "request": "launch",
-      "name": "Renderer",
+      "name": "Renderer(inspector)",
+      "url": "http://localhost:9222",
+      "webRoot": "${workspaceFolder}/dist/packages/renderer",
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Main(vite)",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "runtimeArgs": [
+        "${workspaceFolder}/dist/main/index.cjs",
+      ],
+      "env": {
+        "VITE_DEV_SERVER_HOST": "127.0.0.1",
+        "VITE_DEV_SERVER_PORT": "3344",
+      },
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+      "sourceMaps": true
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Renderer(vite)",
       "url": "http://localhost:3344",
       "webRoot": "${workspaceFolder}/packages/renderer",
     },
   ],
   "compounds": [
     {
-      "name": "All",
+      "name": "All(inspector)",
       "configurations": [
-        "Renderer",
-        "Main",
-      ]
+        "Renderer(inspector)",
+        "Main(inspector)",
+      ],
+      "preLaunchTask": "npm: prebuild"
+    },
+    {
+      "name": "All(vite serve)",
+      "configurations": [
+        "Renderer(vite)",
+        "Main(vite)",
+      ],
+      "preLaunchTask": "npm: debug"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "prebuild",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: prebuild",
+			"detail": "vue-tsc --project packages/renderer/tsconfig.json --noEmit && node scripts/build.mjs"
+		},
+		{
+			"type": "npm",
+			"script": "debug",
+			"problemMatcher": [],
+			"label": "npm: debug",
+			"detail": "npm run prebuild && vite ./packages/renderer",
+			"group": "build"
+		},
+	]
+}

--- a/packages/main/index.ts
+++ b/packages/main/index.ts
@@ -23,7 +23,7 @@ async function createWindow() {
     },
   })
 
-  if (app.isPackaged) {
+  if (app.isPackaged || process.env["DEBUG"]) {
     win.loadFile(join(__dirname, '../renderer/index.html'))
   } else {
     // 🚧 Use ['ENV_NAME'] avoid vite:define plugin

--- a/packages/main/vite.config.ts
+++ b/packages/main/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       formats: ['cjs'],
       fileName: () => '[name].cjs',
     },
-    minify: false,
+    minify: process.env./* from mode option */NODE_ENV === 'production',
     sourcemap: true,
     emptyOutDir: true,
     rollupOptions: {

--- a/packages/preload/vite.config.ts
+++ b/packages/preload/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       formats: ['cjs'],
       fileName: () => '[name].cjs',
     },
+    sourcemap: true,
     minify: process.env./* from mode option */NODE_ENV === 'production',
     emptyOutDir: true,
     rollupOptions: {

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
   base: './',
   build: {
     emptyOutDir: true,
+    sourcemap: true,
     outDir: '../../dist/renderer',
   },
   server: {


### PR DESCRIPTION


* chrome inspector 调试模式支持
* 将 debug 启动 vite server 脚本移入了 task.json

目前支持两种模式调试
一种是 electron 官方推荐的 inspector node，但是 sourcemap 目前没搞定，推荐在 node\main\render进程环境切换复杂的调试环境使用。这个环境下渲染进程是由浏览器启动的，由服务器管理调试过程。*是官方推荐方式*

另一种思路是 main 进程调试依然是同上的，只不过是去拦截 vite server，当在环境下发生资源请求时浏览器会向 vite server 发送请求、并且加载这个单页面文件并构建，此时调试器拦截到了这个断点，即可调试。*使用方便直观，不适合调试复杂流程*