### PR TITLE
fix(package.json): prebuild runs twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node scripts/watch.mjs",
     "prebuild": "vue-tsc --project packages/renderer/tsconfig.json --noEmit && node scripts/build.mjs",
-    "build": "npm run prebuild && electron-builder",
+    "build": "electron-builder",
     "debug": "npm run prebuild && vite ./packages/renderer"
   },
   "engines": {


### PR DESCRIPTION
When using npm, the prebuild script will run twice if you add `npm run prebuild` in build script.

Here is more [information](https://docs.npmjs.com/cli/v8/using-npm/scripts#pre--post-scripts).